### PR TITLE
feat: add SEO metadata, structured data, sitemap and OG images

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Bricolage_Grotesque, Hanken_Grotesk, JetBrains_Mono } from "next/font/google";
 import { Toaster } from "react-hot-toast";
 
@@ -9,6 +9,7 @@ import Footer from "@/components/Footer";
 import SmoothScroll from "@/components/SmoothScroll";
 import ScrollProgress from "@/components/ScrollProgress";
 import Backdrop from "@/components/Backdrop";
+import { siteConfig, siteUrl } from "@/lib/site";
 
 const display = Bricolage_Grotesque({
   subsets: ["latin"],
@@ -29,9 +30,93 @@ const mono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Pasan Ratnayake — Full-stack Engineer",
-  description:
-    "Full-stack software engineer building fast, production-grade web products with React, Next.js & Node. Open to elite roles and select freelance work.",
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: siteConfig.title,
+    template: `%s — ${siteConfig.name}`,
+  },
+  description: siteConfig.description,
+  keywords: [...siteConfig.keywords],
+  authors: [{ name: siteConfig.name, url: siteUrl }],
+  creator: siteConfig.name,
+  publisher: siteConfig.name,
+  applicationName: `${siteConfig.name} — Portfolio`,
+  category: "technology",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    siteName: `${siteConfig.name} — Portfolio`,
+    title: siteConfig.title,
+    description: siteConfig.description,
+    url: siteUrl,
+    locale: siteConfig.locale,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteConfig.title,
+    description: siteConfig.description,
+    creator: "@pasan1227",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+  icons: {
+    icon: "/favicon.ico",
+  },
+  formatDetection: {
+    telephone: false,
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#080808",
+  colorScheme: "dark",
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: siteConfig.name,
+  url: siteUrl,
+  image: `${siteUrl}/assets/pasan.jpg`,
+  jobTitle: siteConfig.jobTitle,
+  description: siteConfig.description,
+  worksFor: {
+    "@type": "Organization",
+    name: siteConfig.employer,
+  },
+  alumniOf: {
+    "@type": "CollegeOrUniversity",
+    name: siteConfig.alumniOf,
+  },
+  address: {
+    "@type": "PostalAddress",
+    addressLocality: siteConfig.location.city,
+    addressCountry: siteConfig.location.country,
+  },
+  knowsAbout: [
+    "React",
+    "Next.js",
+    "TypeScript",
+    "JavaScript",
+    "Node.js",
+    "NestJS",
+    "Tailwind CSS",
+    "PostgreSQL",
+    "MongoDB",
+    "Full-stack Web Development",
+  ],
+  sameAs: [siteConfig.social.github, siteConfig.social.linkedin],
 };
 
 export default function RootLayout({
@@ -44,6 +129,11 @@ export default function RootLayout({
       <body
         className={`${display.variable} ${body.variable} ${mono.variable} font-sans relative min-h-screen overflow-x-hidden bg-ink-950 text-bone`}
       >
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+
         {/* Hairline grid + one signature glow that drifts on scroll (transform
             only — the blur layer is never repainted). */}
         <Backdrop />

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+
+import { siteConfig } from "@/lib/site";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: `${siteConfig.name} — Portfolio`,
+    short_name: siteConfig.name,
+    description: siteConfig.description,
+    start_url: "/",
+    display: "standalone",
+    background_color: "#080808",
+    theme_color: "#080808",
+    icons: [
+      {
+        src: "/favicon.ico",
+        sizes: "any",
+        type: "image/x-icon",
+      },
+    ],
+  };
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,9 @@
+import { ogAlt, ogContentType, ogSize, renderOgImage } from "@/lib/og";
+
+export const alt = ogAlt;
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function OpengraphImage() {
+  return renderOgImage();
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+import { siteUrl } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+import { siteUrl } from "@/lib/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+}

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,0 +1,9 @@
+import { ogAlt, ogContentType, ogSize, renderOgImage } from "@/lib/og";
+
+export const alt = ogAlt;
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function TwitterImage() {
+  return renderOgImage();
+}

--- a/lib/og.tsx
+++ b/lib/og.tsx
@@ -1,0 +1,138 @@
+import { ImageResponse } from "next/og";
+
+import { siteConfig } from "@/lib/site";
+
+export const ogSize = { width: 1200, height: 630 };
+export const ogAlt = `${siteConfig.name} — ${siteConfig.role}`;
+export const ogContentType = "image/png";
+
+const INK = "#080808";
+const BONE = "#f4f4ee";
+const BONE_MUTED = "#9b9b92";
+const VOLT = "#c9ff3d";
+
+export function renderOgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          backgroundColor: INK,
+          padding: "72px 80px",
+          position: "relative",
+        }}
+      >
+        {/* signature volt glow */}
+        <div
+          style={{
+            position: "absolute",
+            top: -260,
+            right: -200,
+            width: 640,
+            height: 640,
+            borderRadius: "9999px",
+            background: VOLT,
+            opacity: 0.16,
+            filter: "blur(40px)",
+            display: "flex",
+          }}
+        />
+
+        {/* eyebrow */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            fontSize: 26,
+            letterSpacing: 8,
+            textTransform: "uppercase",
+            color: VOLT,
+            fontWeight: 700,
+          }}
+        >
+          {siteConfig.name}
+        </div>
+
+        {/* headline */}
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 116,
+              lineHeight: 0.95,
+              fontWeight: 800,
+              letterSpacing: -4,
+              color: BONE,
+            }}
+          >
+            Full-stack
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 116,
+              lineHeight: 0.95,
+              fontWeight: 800,
+              letterSpacing: -4,
+              color: VOLT,
+            }}
+          >
+            Engineer.
+          </div>
+          <div
+            style={{
+              display: "flex",
+              marginTop: 28,
+              fontSize: 30,
+              color: BONE_MUTED,
+              fontWeight: 500,
+            }}
+          >
+            React · Next.js · NestJS · TypeScript
+          </div>
+        </div>
+
+        {/* footer row */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderTop: "1px solid rgba(255,255,255,0.12)",
+            paddingTop: 28,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 14,
+              fontSize: 26,
+              color: BONE,
+              fontWeight: 600,
+            }}
+          >
+            <div
+              style={{
+                width: 14,
+                height: 14,
+                borderRadius: "9999px",
+                backgroundColor: VOLT,
+                display: "flex",
+              }}
+            />
+            Available for work
+          </div>
+          <div style={{ display: "flex", fontSize: 24, color: BONE_MUTED }}>
+            Open to roles & freelance
+          </div>
+        </div>
+      </div>
+    ),
+    { ...ogSize },
+  );
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,45 @@
+function resolveBaseUrl(): string {
+  // Explicit override — set NEXT_PUBLIC_SITE_URL once a custom domain is live.
+  if (process.env.NEXT_PUBLIC_SITE_URL) {
+    return process.env.NEXT_PUBLIC_SITE_URL.replace(/\/+$/, "");
+  }
+  // Vercel injects the stable production domain at build time.
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+  return "http://localhost:3000";
+}
+
+export const siteUrl = resolveBaseUrl();
+
+export const siteConfig = {
+  name: "Pasan Ratnayake",
+  title: "Pasan Ratnayake — Full-stack Engineer",
+  role: "Full-stack Engineer",
+  jobTitle: "Software Engineer",
+  description:
+    "Full-stack software engineer building fast, production-grade web products with React, Next.js, NestJS & TypeScript. Open to elite engineering roles and select freelance work.",
+  url: siteUrl,
+  locale: "en_US",
+  location: { city: "Kandy", country: "Sri Lanka" },
+  employer: "BotCalm",
+  alumniOf: "University of Staffordshire",
+  social: {
+    github: "https://github.com/pasan1227",
+    linkedin: "https://www.linkedin.com/in/pasanratnayake/",
+  },
+  keywords: [
+    "Pasan Ratnayake",
+    "Full-stack Engineer",
+    "Software Engineer",
+    "React Developer",
+    "Next.js Developer",
+    "NestJS",
+    "TypeScript",
+    "Node.js",
+    "Web Developer Sri Lanka",
+    "Freelance Software Engineer",
+  ],
+} as const;
+
+export type SiteConfig = typeof siteConfig;


### PR DESCRIPTION
Wire up Open Graph/Twitter cards, JSON-LD Person schema, robots, sitemap, web manifest and a dynamically generated volt/dark share card. Base URL resolves from VERCEL_PROJECT_PRODUCTION_URL with a NEXT_PUBLIC_SITE_URL override for a future custom domain.