### PR TITLE
fix: noindex CV.pdf so the site outranks the raw PDF in search

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,16 @@ const nextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        // Keep the CV downloadable but out of search results so the site
+        // itself ranks as the primary result, not the raw PDF.
+        source: "/CV.pdf",
+        headers: [{ key: "X-Robots-Tag", value: "noindex" }],
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Google was indexing /CV.pdf and surfacing it above the homepage for "pasan ratnayake", sending clicks to the PDF. Serve X-Robots-Tag: noindex (crawling still allowed so Google can see it and drop the PDF); the download link is unaffected.