### PR TITLE
feat: support Google Search Console verification via env var

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -70,6 +70,9 @@ export const metadata: Metadata = {
       "max-video-preview": -1,
     },
   },
+  verification: process.env.GOOGLE_SITE_VERIFICATION
+    ? { google: process.env.GOOGLE_SITE_VERIFICATION }
+    : undefined,
   icons: {
     icon: "/favicon.ico",
   },


### PR DESCRIPTION
Render the google-site-verification meta tag from GOOGLE_SITE_VERIFICATION when set, so the property can be verified without committing the token.